### PR TITLE
Mark network packets as handled to prevent "Unknown custom packet identifier" warnings on the server and client

### DIFF
--- a/src/main/java/de/maxhenkel/easyvillagers/net/MessageCycleTrades.java
+++ b/src/main/java/de/maxhenkel/easyvillagers/net/MessageCycleTrades.java
@@ -20,6 +20,7 @@ public class MessageCycleTrades implements Message<MessageCycleTrades> {
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         GuiEvents.onCycleTrades(context.getSender());
+        context.setPacketHandled(true);
     }
 
     @Override

--- a/src/main/java/de/maxhenkel/easyvillagers/net/MessagePickUpVillager.java
+++ b/src/main/java/de/maxhenkel/easyvillagers/net/MessagePickUpVillager.java
@@ -34,6 +34,7 @@ public class MessagePickUpVillager implements Message<MessagePickUpVillager> {
         player.level().getEntitiesOfClass(Villager.class, player.getBoundingBox().inflate(8D), v -> v.getUUID().equals(villager)).stream().filter(VillagerEvents::arePickupConditionsMet).findAny().ifPresent(villagerEntity -> {
             VillagerEvents.pickUp(villagerEntity, player);
         });
+        context.setPacketHandled(true);
     }
 
     @Override

--- a/src/main/java/de/maxhenkel/easyvillagers/net/MessageSelectTrade.java
+++ b/src/main/java/de/maxhenkel/easyvillagers/net/MessageSelectTrade.java
@@ -35,6 +35,7 @@ public class MessageSelectTrade implements Message<MessageSelectTrade> {
                 container.getTrader().prevTrade();
             }
         }
+        context.setPacketHandled(true);
     }
 
     @Override

--- a/src/main/java/de/maxhenkel/easyvillagers/net/MessageVillagerParticles.java
+++ b/src/main/java/de/maxhenkel/easyvillagers/net/MessageVillagerParticles.java
@@ -33,6 +33,7 @@ public class MessageVillagerParticles implements Message<MessageVillagerParticle
             BreederTileentity breeder = (BreederTileentity) tileEntity;
             breeder.spawnParticles();
         }
+        context.setPacketHandled(true);
     }
 
     @Override


### PR DESCRIPTION
This fixes (already closed/marked as 'not planned') issue #196, which was caused by missing calls to `NetworkEvent.Context#setPacketHandler` to mark the network packet as handled. 