### PR TITLE
Fix auto trader trades with additional item data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,1 @@
-- Updated Chinese Simplified (China) translation
+- Fixed auto trader not accepting trade items with additional data components

--- a/src/main/java/de/maxhenkel/easyvillagers/blocks/tileentity/AutoTraderTileentity.java
+++ b/src/main/java/de/maxhenkel/easyvillagers/blocks/tileentity/AutoTraderTileentity.java
@@ -14,6 +14,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.npc.villager.Villager;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.trading.ItemCost;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraft.world.item.trading.MerchantOffers;
 import net.minecraft.world.level.block.Block;
@@ -65,10 +66,10 @@ public class AutoTraderTileentity extends TraderTileentityBase implements ITicka
 
 
         try (Transaction transaction = Transaction.open(null)) {
-            if (!removeNeededItems(getAutoTradeInputA(), transaction)) {
+            if (!removeNeededItems(offer.getItemCostA(), getAutoTradeInputA().getCount(), transaction)) {
                 return;
             }
-            if (!removeNeededItems(offer.getCostB(), transaction)) {
+            if (offer.getItemCostB().isPresent() && !removeNeededItems(offer.getItemCostB().get(), offer.getCostB().getCount(), transaction)) {
                 return;
             }
             if (!insertItems(offer.getResult(), transaction)) {
@@ -87,12 +88,22 @@ public class AutoTraderTileentity extends TraderTileentityBase implements ITicka
         setChanged();
     }
 
-    protected boolean removeNeededItems(ItemStack buying, TransactionContext transaction) {
-        if (buying.isEmpty()) {
+    protected boolean removeNeededItems(ItemCost cost, int amount, TransactionContext transaction) {
+        if (amount <= 0) {
             return true;
         }
-        int extract = inputInventory.extract(ItemResource.of(buying), buying.getCount(), transaction);
-        return extract >= buying.getCount();
+        int extracted = 0;
+        for (int i = 0; i < inputInventory.size(); i++) {
+            ItemResource resource = inputInventory.getResource(i);
+            if (resource.isEmpty() || !resource.test(cost::test)) {
+                continue;
+            }
+            extracted += inputInventory.extract(i, resource, amount - extracted, transaction);
+            if (extracted >= amount) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected boolean insertItems(ItemStack insert, TransactionContext transaction) {


### PR DESCRIPTION
## What changed

- Match auto-trader inputs with the selected offer's `ItemCost` predicate.
- Extract the actual resource stored in each input slot, preserving its data components.
- Continue to enforce components explicitly required by an offer.
- Document the fix in the changelog.

## Why

The auto trader previously converted the offer's displayed cost stack into an `ItemResource` and extracted it by exact resource equality. Items with additional data components, such as Productive Farming crops or the `minecraft:custom_data` example from #322, therefore failed to match even though vanilla villager trading accepts them.

Using `ItemCost.test` aligns automatic trading with `MerchantOffer.satisfiedBy`: additional components are allowed, while components required by the offer still have to match.

## Impact

Auto traders can now consume otherwise valid trade inputs carrying additional data components. Multi-slot extraction and transactional rollback behavior are preserved.

## Validation

- `./gradlew build`
- Targeted regression check using carrots with `minecraft:custom_data`
- Verified that a mismatched explicitly required component is rejected
- Verified that an insufficient extraction is rolled back

Closes #322
